### PR TITLE
New: Enable to skip inherited properties and methods

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -10,6 +10,12 @@ namespace Z\IdeStubGenerator;
 abstract class Generator
 {
     /**
+     * Skip properties and methods inherited from parent classes, interfaces or traits
+     * @var bool
+     */
+    private $skipInheritedMembers = false;
+
+    /**
      * Class names for generation
      * Structure:
      * Array(
@@ -131,6 +137,22 @@ abstract class Generator
     public function setConstants(array $constants)
     {
         $this->constants = $constants;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSkipInheritedMembers()
+    {
+        return $this->skipInheritedMembers;
+    }
+
+    /**
+     * @param bool $skipInheritedMembers
+     */
+    public function setSkipInheritedMembers($skipInheritedMembers)
+    {
+        $this->skipInheritedMembers = $skipInheritedMembers;
     }
 
     /**
@@ -260,6 +282,9 @@ abstract class Generator
         }
         ksort($properties);
         foreach ($properties as $property) {
+            if($this->isSkipInheritedMembers() && $property->class !== $reflection->getName()) {
+                continue;
+            }
 
             $property_info = array();
             $property_info['name'] = $property->getName();
@@ -306,6 +331,9 @@ abstract class Generator
 
         $methods = array();
         foreach ($reflection->getMethods() as $method) {
+            if($this->isSkipInheritedMembers() && $property->class !== $reflection->getName()) {
+                continue;
+            }
             $methods[$method->getName()] = $method;
         }
         ksort($methods);


### PR DESCRIPTION
I am documenting my company's framework and I found that the generated stub is greatly reduced when parent properites and methods are not used.

In the set of 280 classes, the generated documentation was reduced from 90k lines to 35k